### PR TITLE
ci: workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,8 @@
 # @see https://github.com/actions/virtual-environments
 # @see https://www.postgresql.jp/document/11/html/app-pgrestore.html
 name: Test
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/supercaracal/scram-sha-256/security/code-scanning/4](https://github.com/supercaracal/scram-sha-256/security/code-scanning/4)

In general, the fix is to add a `permissions` block that explicitly scopes the `GITHUB_TOKEN` to the minimum required privileges. Since this workflow only checks out code and runs tests/benchmarks against local services, it appears to need only read access to repository contents, and no write permissions.

The safest, least intrusive fix is to add a workflow-level `permissions` block near the top of `.github/workflows/test.yaml`, right after the `name: Test` line and before `on:`. This will apply to all jobs (`unit`, `lint`, `profiling`, and `feature`) and restrict `GITHUB_TOKEN` to read-only repository contents, which matches how `actions/checkout` works by default. No existing steps need to be changed, and no new imports or actions are necessary.

Concretely:
- Edit `.github/workflows/test.yaml`.
- Insert:
  ```yaml
  permissions:
    contents: read
  ```
  after line 6 (`name: Test`).
- No other lines require modification.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
